### PR TITLE
fix: listing resource templates error when not supported

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -8,9 +8,12 @@ pub struct MyClientHandler;
 impl ClientHandler for MyClientHandler {
     async fn handle_process_error(
         &self,
-        _error_message: String,
-        _: &dyn McpClient,
+        error_message: String,
+        runtime: &dyn McpClient,
     ) -> std::result::Result<(), RpcError> {
+        if !runtime.is_shut_down().await {
+            eprintln!("{}", error_message);
+        }
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,7 +438,7 @@ impl McpDiscovery {
         match result {
             Ok(data) => Ok(Some(data.resource_templates)),
             Err(err) => {
-                tracing::trace!("Unable to retrieve resource templates : {}", err);
+                eprintln!("Unable to retrieve resource templates : {}", err);
                 Ok(None)
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,12 +432,16 @@ impl McpDiscovery {
             return Ok(None);
         }
 
-        let resource_templates: Vec<ResourceTemplate> = client
+        let result = client
             .list_resource_templates(Some(ListResourceTemplatesRequestParams::default()))
-            .await?
-            .resource_templates;
-
-        Ok(Some(resource_templates))
+            .await;
+        match result {
+            Ok(data) => Ok(Some(data.resource_templates)),
+            Err(err) => {
+                tracing::trace!("Unable to retrieve resource templates : {}", err);
+                Ok(None)
+            }
+        }
     }
 
     pub async fn discover(&mut self) -> DiscoveryResult<&McpServerInfo> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -92,9 +92,6 @@ pub fn get_absolute_from_relative(
 
     let cwd = std::env::current_dir()?;
     Ok(cwd.join(joined_path).clean())
-
-    // Convert to absolute path (resolving symlinks and normalizing)
-    // Ok(fs::canonicalize(&joined_path).unwrap_or_else(|_| joined_path))
 }
 
 pub fn find_template_file(


### PR DESCRIPTION
### 📌 Summary
The CLI previously failed when attempting to retrieve a list of resource templates when the feature wasn't supported. This issue has been resolved—now, instead of failing, it returns None when resource templates are not supported.

