### PR TITLE
feat: add support for $ref in JSON Schema Parser

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod templates;
 mod types;
 mod utils;
 
+use serde_json::{to_value, Map, Value};
 pub use templates::OutputTemplate;
 pub use types::{
     DiscoveryCommand, LogLevel, McpCapabilities, McpServerInfo, McpToolMeta, ParamTypes,
@@ -328,7 +329,9 @@ impl McpDiscovery {
         let mut tools: Vec<_> = tools_result
             .iter()
             .map(|tool| {
-                let params = tool_params(&tool.input_schema.properties);
+                let root_schema: serde_json::Value =
+                    to_value(&tool.input_schema).unwrap_or_else(|_| Value::Object(Map::new()));
+                let params = tool_params(&tool.input_schema.properties, &root_schema);
 
                 Ok::<McpToolMeta, DiscoveryError>(McpToolMeta {
                     name: tool.name.to_owned(),

--- a/templates/html/html_tools.hbs
+++ b/templates/html/html_tools.hbs
@@ -21,7 +21,7 @@
             <td>
                 <ul>
                     {{#each this.params}}
-                    <li style="white-space: nowrap;"> <code>{{{this.param_name}}}</code> : {{{tool_param_type
+                    <li style=""> <code>{{{this.param_name}}}</code> : {{{tool_param_type
                         this.param_type}}}<br /></li>
                     {{/each}}
                 </ul>

--- a/templates/markdown/md_tools.hbs
+++ b/templates/markdown/md_tools.hbs
@@ -21,7 +21,7 @@
             <td>
                 <ul>
                     {{#each this.params}}
-                    <li style="white-space: nowrap;"> <code>{{{this.param_name}}}</code> : {{{tool_param_type
+                    <li> <code>{{{this.param_name}}}</code> : {{{tool_param_type
                         this.param_type}}}<br /></li>
                     {{/each}}
                 </ul>


### PR DESCRIPTION
### 📌 Summary
This PR adds support for the `$ref` keyword in the JSON Schema parser, enabling the resolution of schema references like `#/properties/data/properties/name`. Previously, the parser did not handle `$ref`, limiting its ability to process complex schemas with reused definitions.


### 💡 Additional Notes
This PR enables parsing of JSON Schemas with `$ref`, such as the example payload's `subdistricts` items referencing `#/properties/data/properties/name`.
- No breaking changes to existing functionality; schemas without `$ref` are processed as before.

