### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # MCP Discovery
 
+[![MCP Toplist](https://mcptoplist.com/badge/mcp.so%2Fmcp-discovery%2Frust-mcp-stack.svg)](https://mcptoplist.com/server/mcp.so%2Fmcp-discovery%2Frust-mcp-stack)
+
 A command-line tool written in Rust for discovering and documenting MCP Server capabilities.
 
 It supports outputting the results in the terminal or saving them to files in [Markdown](https://github.com/rust-mcp-stack/mcp-discovery/blob/main/docs/examples/update-md.md#server-info-and-capabilities), [HTML](https://rust-mcp-stack.github.io/mcp-discovery/examples/server-info.html), [plain text](https://rust-mcp-stack.github.io/mcp-discovery/examples/capabilities.txt), JSON, or a custom template defined by you.


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 95,385 MCP servers across the major
registries, and **MCP Discovery MCP Server** is currently ranked **#5,835**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/mcp.so%2Fmcp-discovery%2Frust-mcp-stack.svg)](https://mcptoplist.com/server/mcp.so%2Fmcp-discovery%2Frust-mcp-stack)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building MCP Discovery MCP Server!
